### PR TITLE
Add ability for Grug to set reminders

### DIFF
--- a/grug/__main__.py
+++ b/grug/__main__.py
@@ -4,7 +4,7 @@ import anyio
 from loguru import logger
 
 from grug.db import run_db_migrations
-from grug.discord_client import DiscordClient
+from grug.discord_client import discord_client
 from grug.scheduler import start_scheduler
 from grug.settings import settings
 
@@ -24,7 +24,7 @@ async def main():
     run_db_migrations()
 
     async with anyio.create_task_group() as tg:
-        tg.start_soon(DiscordClient().start, settings.discord_token.get_secret_value())
+        tg.start_soon(discord_client.start, settings.discord_token.get_secret_value())
         tg.start_soon(start_scheduler)
 
     logger.info("Grug has shut down...")

--- a/grug/ai_agent.py
+++ b/grug/ai_agent.py
@@ -9,6 +9,7 @@ from langgraph.store.memory import BaseStore, InMemoryStore
 from grug.ai_tools.dice_roller import roll_dice
 from grug.ai_tools.image_generation import generate_ai_image
 from grug.ai_tools.information_search import search_archives_of_nethys
+from grug.ai_tools.reminders import set_reminder
 from grug.settings import settings
 
 
@@ -25,11 +26,7 @@ def get_react_agent(
             max_retries=2,
             openai_api_key=settings.openai_api_key,
         ),
-        tools=[
-            roll_dice,
-            search_archives_of_nethys,
-            generate_ai_image,
-        ],
+        tools=[roll_dice, search_archives_of_nethys, generate_ai_image, set_reminder],
         checkpointer=checkpointer,
         store=store,
         prompt=orjson.dumps(
@@ -38,6 +35,7 @@ def get_react_agent(
                     f"your name is {settings.ai_name}.",
                     "You are an expert in Pathfinder 2E, and should leverage the archives of nethys for ALL pathfinder information.",
                     "You should respond conversationally, but remember to format your responses in markdown when providing information and details.",
+                    "When the user is requesting a reminder or scheduling an event, ALWAYS use the tool, even if they just asked you to set a reminder.",
                 ],
                 "secondary_instructions": settings.ai_instructions if settings.ai_instructions else "",
             }

--- a/grug/ai_tools/reminders.py
+++ b/grug/ai_tools/reminders.py
@@ -1,8 +1,131 @@
-# TODO: tie into the scheduler to set reminders that can be sent back to the user or group chat
-from typing import Annotated
+from apscheduler.triggers.cron import CronTrigger
+from apscheduler.triggers.date import DateTrigger
+from langchain_core.runnables import RunnableConfig
+from langchain_core.tools import tool
+from langchain_openai import ChatOpenAI
+from typing import Literal, Optional
+from datetime import datetime, UTC
+import json
+from langchain_core.messages import HumanMessage, SystemMessage
+from loguru import logger
+from pydantic import BaseModel, Field, computed_field
 
-from langchain_core.tools import InjectedToolArg
+from grug.scheduler import scheduler
+from grug.settings import settings
 
 
-async def set_reminder(message: str, user_id: Annotated[str, InjectedToolArg]):
-    pass
+class ScheduleResponse(BaseModel):
+    """Response model for schedule processing."""
+
+    schedule_prompt: str = Field(..., description="The original schedule request.")
+    schedule_type: Literal["cron", "datetime"] | None = Field(None, description="The type of schedule format.")
+    schedule_value: str | None = Field(None, description="The formatted schedule value.")
+    clarification: Optional[str] = Field(
+        None, description="Clarification or feedback on the schedule request required from the user."
+    )
+
+    @computed_field
+    @property
+    def schedule(self) -> str | datetime:
+        """Returns the schedule in the appropriate format."""
+        if self.clarification:
+            raise ValueError(f"Clarification needed: {self.clarification}")
+
+        if self.schedule_type == "cron":
+            return self.schedule_value
+        else:
+            return datetime.fromisoformat(self.schedule_value)
+
+
+def get_schedule(schedule_prompt: str) -> ScheduleResponse:
+    model = ChatOpenAI(
+        model_name="gpt-4o-mini",
+        temperature=0,
+        max_tokens=None,
+        max_retries=2,
+        openai_api_key=settings.openai_api_key,
+    )
+
+    return model.with_structured_output(ScheduleResponse).invoke(
+        [
+            SystemMessage(
+                json.dumps(
+                    [
+                        "You will be given a schedule request.",
+                        "Identify the type of schedule (e.g., cron, datetime) and convert it to the appropriate format.",
+                        "If the request is ambiguous, ask for clarification.",
+                        "If it's a recurring schedule, convert to a cron string (e.g., '0 12 * * 1-5' for weekdays at noon).",
+                        "If it's a specific or relative time, convert to ISO datetime format.",
+                        f"The current UTC datetime in ISO format is {datetime.now(tz=UTC).isoformat()}",
+                    ]
+                )
+            ),
+            HumanMessage(schedule_prompt),
+        ]
+    )
+
+
+async def send_reminder(
+    message: str,
+    discord_channel_id: str,
+    discord_user_id: str,
+    discord_guild_id: str | None,
+) -> None:
+    from grug.discord_client import discord_client
+
+    # TODO: figure out how to get the original message id so we can reference it in the reminder message
+    if not discord_guild_id:
+        await discord_client.get_user(int(discord_user_id)).send(message)
+        print(f"Sent reminder to user {discord_user_id}: {message}")
+    else:
+        channel = discord_client.get_guild(int(discord_guild_id)).get_channel(int(discord_channel_id))
+        await channel.send(f"Reminder for <@{discord_user_id}>: {message}")
+
+
+@tool(parse_docstring=True)
+async def set_reminder(
+    config: RunnableConfig,
+    schedule_prompt: str,
+    message: str | None = None,
+) -> str:
+    """
+    Sets a reminder for the user.
+
+    Args:
+        config (RunnableConfig): The configuration for the reminder.
+        schedule_prompt (str): Prompt for when to schedule the reminder for.  This can be a date, time, a relative time (e.g. "in 2 hours"), or a recurring time (e.g. "every day at 3pm").
+        message (str): The message to send when the reminder is triggered.  If not provided, a default message will be used.
+    """
+    logger.info(f"Scheduling reminder with prompt: {schedule_prompt} and message: {message}")
+
+    discord_channel_id = config["metadata"].get("thread_id")
+    user_id = config["metadata"].get("user_id")
+    if "-" in user_id:
+        discord_guild_id = user_id.split("-")[0]
+        discord_user_id = user_id.split("-")[1]
+    else:
+        discord_guild_id = None
+        discord_user_id = user_id
+
+    reminder_schedule = get_schedule(schedule_prompt).schedule
+    if isinstance(reminder_schedule, str):
+        trigger = CronTrigger.from_crontab(reminder_schedule)
+    elif isinstance(reminder_schedule, datetime):
+        trigger = DateTrigger(run_time=reminder_schedule)
+    else:
+        raise ValueError("Invalid schedule format.")
+
+    schedule_id = await scheduler.add_schedule(
+        func_or_task_id=send_reminder,
+        trigger=trigger,
+        kwargs={
+            "message": message or "This is your reminder!",
+            "discord_channel_id": discord_channel_id,
+            "discord_user_id": discord_user_id,
+            "discord_guild_id": discord_guild_id,
+        },
+    )
+
+    # TODO: put the reminder into memory store so that it can be looked up later when the user wants to adjust it
+    #       or look it up.
+    return f"Reminder scheduled with id: {schedule_id}"

--- a/grug/ai_tools/reminders.py
+++ b/grug/ai_tools/reminders.py
@@ -1,12 +1,13 @@
+import json
+from datetime import UTC, datetime
+from typing import Literal, Optional
+
 from apscheduler.triggers.cron import CronTrigger
 from apscheduler.triggers.date import DateTrigger
+from langchain_core.messages import HumanMessage, SystemMessage
 from langchain_core.runnables import RunnableConfig
 from langchain_core.tools import tool
 from langchain_openai import ChatOpenAI
-from typing import Literal, Optional
-from datetime import datetime, UTC
-import json
-from langchain_core.messages import HumanMessage, SystemMessage
 from loguru import logger
 from pydantic import BaseModel, Field, computed_field
 
@@ -28,9 +29,13 @@ class ScheduleResponse(BaseModel):
     @property
     def schedule(self) -> str | datetime:
         """Returns the schedule in the appropriate format."""
+        # Validation
         if self.clarification:
             raise ValueError(f"Clarification needed: {self.clarification}")
+        if not self.schedule_value:
+            raise ValueError("No schedule value provided.")
 
+        # Return the schedule in the appropriate format
         if self.schedule_type == "cron":
             return self.schedule_value
         else:

--- a/grug/discord_client.py
+++ b/grug/discord_client.py
@@ -473,6 +473,9 @@ class DiscordClient(discord.Client):
                         )
                     )
 
+                # Give the agent the current timestamp
+                messages.append(SystemMessage(f"The current epoch timestamp is {datetime.now().timestamp()}"))
+
                 # Add the message that the user sent
                 messages.append(HumanMessage(message.content))
 
@@ -566,3 +569,6 @@ class InterceptLogHandler(logging.Handler):
                 depth += 1
 
         logger.opt(depth=depth, exception=record.exc_info).log(level, record.getMessage())
+
+
+discord_client: DiscordClient = DiscordClient()


### PR DESCRIPTION
This pull request includes several changes to the `grug` project, focusing on refactoring, adding new tools, and improving the reminder functionality. The most important changes are summarized below:

### Refactoring

* Changed the import of `DiscordClient` to `discord_client` in `grug/__main__.py` and updated its usage accordingly. [[1]](diffhunk://#diff-235f5a6141f83a19d338414b2582dd58f2b9d84253ab805b6862b0bcce88f1c0L7-R7) [[2]](diffhunk://#diff-235f5a6141f83a19d338414b2582dd58f2b9d84253ab805b6862b0bcce88f1c0L27-R27)

### New Tool Addition

* Added a new tool `set_reminder` in `grug/ai_tools/reminders.py` to handle reminder scheduling and sending. [[1]](diffhunk://#diff-01dba24e49d78d3a086150123ece9f107fa38447bc998709311286ee81bb60b0R12) [[2]](diffhunk://#diff-2fec5f452246936fbfc59f8772e97b7cb8c834de127d6091b79a6a2d9c6a37bdL1-R136)

### Reminder Functionality

* Updated `get_react_agent` in `grug/ai_agent.py` to include the new `set_reminder` tool and added instructions for using the tool when setting reminders. [[1]](diffhunk://#diff-01dba24e49d78d3a086150123ece9f107fa38447bc998709311286ee81bb60b0L28-R29) [[2]](diffhunk://#diff-01dba24e49d78d3a086150123ece9f107fa38447bc998709311286ee81bb60b0R38)
* Implemented detailed logic for scheduling reminders using `apscheduler` and handling different schedule formats in `grug/ai_tools/reminders.py`.

### Miscellaneous

* Added the current epoch timestamp to the agent's messages in `on_message` in `grug/discord_client.py`.
* Initialized `discord_client` as an instance of `DiscordClient` in `grug/discord_client.py`.